### PR TITLE
Example of python C extension

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+# Include the README
+include README.md
+
+# Include the license file
+# include LICENSE.txt
+
+# Include the C source files
+PySVF/special_funcs.c
+PySVF/special_funcs.h
+PySVF/svfmodule.c

--- a/PySVF/special_funcs.c
+++ b/PySVF/special_funcs.c
@@ -1,0 +1,9 @@
+#include "special_funcs.h"
+
+double log_original_c(double f) {
+    return log(f);
+}
+
+double sin_original_c(double f) {
+    return sin(f);
+}

--- a/PySVF/special_funcs.h
+++ b/PySVF/special_funcs.h
@@ -1,0 +1,4 @@
+#include <math.h> 
+
+double log_original_c(double f);
+double sin_original_c(double f);

--- a/PySVF/svfmodule.c
+++ b/PySVF/svfmodule.c
@@ -1,0 +1,56 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "special_funcs.h"
+
+// These are "wrapper functions" that you will call from Python
+// Takes python input, changes into C variables and calls the respective C function
+static PyObject *
+svf_log(PyObject *self, PyObject *args)
+{
+    double input_value;
+
+    if (!PyArg_ParseTuple(args, "d", &input_value))
+        return NULL;
+    double log_result = log_original_c(input_value);
+
+    return Py_BuildValue("f", log_result);
+}
+
+// Have one wrapper function for each function you want to expose in Python
+static PyObject *
+svf_sin(PyObject *self, PyObject *args)
+{
+    double input_value;
+
+    if (!PyArg_ParseTuple(args, "d", &input_value))
+        return NULL;
+    double sin_result = sin_original_c(input_value);
+
+    return Py_BuildValue("f", sin_result);
+}
+
+// Define the "method table"
+static PyMethodDef SVFMethods[] = {
+    {"svf_log",  svf_log, METH_VARARGS,
+     "Calculate the natural logarithm of a number."},
+    {"svf_sin",  svf_sin, METH_VARARGS,
+     "Calculate the sine of a number."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+//Set the module definition structure
+static struct PyModuleDef svfmodule = {
+    PyModuleDef_HEAD_INIT,
+    "svfmodule",   /* name of module */
+    NULL,          /* module documentation, may be NULL */
+    -1,            /* size of per-interpreter state of the module,
+                 or -1 if the module keeps state in global variables. */
+    SVFMethods
+};
+
+//Set the module’s initialization function
+PyMODINIT_FUNC PyInit_svfmodule(void) {
+  PyObject *m;
+  m = PyModule_Create(&svfmodule);
+  return m;
+}

--- a/pysvf.py
+++ b/pysvf.py
@@ -1,0 +1,9 @@
+import svfmodule
+
+def py_log(number):
+    "Return the natural logarithm of a number"
+    return svfmodule.svf_log(number)
+
+def py_sin(number):
+    "Return the sine of a number"
+    return svfmodule.svf_sin(number)

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,23 @@
-#from setuptools import setup
-from distutils.core import setup, Extension
-from Cython.Build import cythonize
-from Cython.Distutils import build_ext
-from os.path import join, dirname
-import numpy
+from setuptools import setup, Extension
+import os
 
-#setup(ext_modules = cythonize('PySVF/*.pyx'))#Levanta todos los "pyx"
-src = ["io_c.pyx","io.c"]
-src = [join('PySVF', x) for x in src]
+svf_module = Extension(
+    "svfmodule",
+    sources=[
+        os.path.join("PySVF", "special_funcs.c"),
+        os.path.join("PySVF", "svfmodule.c"),
+        ],
+    include_dirs=["PySVF"],
+    libraries=["m"],
+    extra_compile_args=["-std=c99"],
+)
 
-dep = ["allvars.h","proto.h"]
-dep = [join('PySVF', x) for x in dep]
-
-
-setup(cmdclass={'build_ext':build_ext}, ext_modules=[Extension('io_c', sources=src,depends=dep,include_dirs=[numpy.get_include()])])
-
-
-
-#setup(ext_modules = cythonize('Examples/*.pyx'))#Examples:"hello_word.c"y"rectangle.c"
+setup(
+    name="pysvf",
+    version="0.1",
+    description="A Python Module for SVF",
+    author="German Alfaro",
+    url="https://github.com/geralfaro/PySVF",
+    py_modules=["pysvf"],
+    ext_modules=[svf_module],
+)


### PR DESCRIPTION
This is how a C extension would look like. I don't know the SVF functionality, you'll have to decide which functions are worth exporting to Python to interface with user. In the example I export the functions in special_funcs.c that return C doubles and are converted to python floats. You need a wrapper C function svfmodule.c to interface with your true python module pysvf.py.